### PR TITLE
Drtii 924 group ports by region

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val specs2Version = "4.6.0"
 lazy val logBackJsonVersion = "0.1.5"
 
 lazy val drtCiriumVersion = "56"
-lazy val drtLibVersion = "v155"
+lazy val drtLibVersion = "v156"
 lazy val janinoVersion = "3.1.6"
 lazy val scalaTestVersion = "3.2.9"
 lazy val jacksonDatabindVersion = "2.11.2"

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val specs2Version = "4.6.0"
 lazy val logBackJsonVersion = "0.1.5"
 
 lazy val drtCiriumVersion = "56"
-lazy val drtLibVersion = "v154"
+lazy val drtLibVersion = "v155"
 lazy val janinoVersion = "3.1.6"
 lazy val scalaTestVersion = "3.2.9"
 lazy val jacksonDatabindVersion = "2.11.2"

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val specs2Version = "4.6.0"
 lazy val logBackJsonVersion = "0.1.5"
 
 lazy val drtCiriumVersion = "56"
-lazy val drtLibVersion = "v156"
+lazy val drtLibVersion = "v158"
 lazy val janinoVersion = "3.1.6"
 lazy val scalaTestVersion = "3.2.9"
 lazy val jacksonDatabindVersion = "2.11.2"

--- a/react/src/App.css
+++ b/react/src/App.css
@@ -80,7 +80,7 @@ html {
 }
 
 #global-header .header-proposition {
-    padding-top: 10px;
+    padding: 10px;
 }
 
 #global-header.with-proposition .header-wrapper .header-proposition .content {
@@ -109,7 +109,8 @@ html {
 #global-header-bar {
     height: 10px;
     background-color: #005ea5;
-    margin: 0 30px;
+    margin: auto;
+    max-width: 1300px;
 }
 
 #footer {

--- a/react/src/App.css
+++ b/react/src/App.css
@@ -12,7 +12,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     font-size: calc(10px + 2vmin);
 }
 
@@ -33,7 +32,7 @@
 
 #global-header .header-wrapper {
     background-color: #0b0c0c;
-    max-width: 1280px;
+    max-width: 1180px;
     margin: 0 auto;
     padding-top: 8px;
     padding-bottom: 8px;
@@ -110,7 +109,7 @@ html {
     height: 10px;
     background-color: #005ea5;
     margin: auto;
-    max-width: 1300px;
+    max-width: 1200px;
 }
 
 #footer {

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './App.css';
-import Home from './components/Home';
+import {Home} from './components/Home';
 import Alerts from './components/Alerts/Alerts';
 import {Route, Switch} from "react-router-dom";
 import Loading from "./components/Loading";
@@ -20,7 +20,7 @@ const StyledDiv = styled('div')(() => ({
 }));
 
 const StyledContainer = styled(Container)(() => ({
-  margin: 30,
+  margin: 5,
   padding: 15,
   textAlign: 'left',
   minHeight: 500,

--- a/react/src/components/AccessRequestForm.tsx
+++ b/react/src/components/AccessRequestForm.tsx
@@ -32,7 +32,6 @@ const ThankYouBox = styled(Box)(() => ({
 
 interface IProps {
   regions: PortRegion[];
-  ports: string[];
   teamEmail: string;
 }
 

--- a/react/src/components/AccessRequestForm.tsx
+++ b/react/src/components/AccessRequestForm.tsx
@@ -8,11 +8,11 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import Checkbox from "@mui/material/Checkbox";
 import ListItemText from "@mui/material/ListItemText";
 import Divider from "@mui/material/Divider";
-import {Box, FormControl, Paper, TextField, Typography} from "@mui/material";
+import {Box, FormControl, Grid, TextField, Typography} from "@mui/material";
 import Button from "@mui/material/Button";
 
 
-const StyledPaper = styled(Paper)(({theme}) => ({
+const Declaration = styled('div')(({theme}) => ({
   textAlign: "left",
   padding: theme.spacing(2),
   width: '100%',
@@ -45,6 +45,31 @@ interface IState {
   requestSubmitted: boolean;
 }
 
+const regions =
+  [
+    {
+      name: 'North',
+      ports: ["BFS", "BHD", "DSA", "EDI", "GLA", "HUY", "LBA", "LPL", "MAN", "MME", "NCL", "PIK"]
+    },
+    {
+      name: 'Central',
+      ports: ["BHX", "EMA", "LCY", "LTN", "NYI", "STN"]
+    },
+    {
+      name: 'South',
+      ports: ["BOH", "BRS", "CWL", "EXT", "LGW", "NQY", "SOU"]
+    },
+    {
+      name: 'Heathrow',
+      ports: ["LHR"]
+    }
+  ]
+
+const Region = styled('p')(() => ({
+  fontSize: '21px',
+  fontWeight: 'bold',
+}));
+
 export default function AccessRequestForm(props: IProps) {
   const [state, setState] = React.useState(
     {
@@ -56,9 +81,9 @@ export default function AccessRequestForm(props: IProps) {
       requestSubmitted: false,
     } as IState);
 
+  regions
 
   const updatePortSelection = (port: string) => {
-
     const requested: string[] = state.portsRequested.includes(port) ?
       state.portsRequested.filter(value => value !== port) :
       [
@@ -85,8 +110,9 @@ export default function AccessRequestForm(props: IProps) {
 
 
   function form(portsAvailable: string[]) {
-    const sortedPorts = [...portsAvailable].sort()
-    return <div>
+    portsAvailable
+    // const sortedPorts = [...portsAvailable].sort()
+    return <Box sx={{width: '100%'}}>
       <h1>Welcome to DRT</h1>
       <p>Please select the ports you require access to</p>
       <List>
@@ -103,22 +129,33 @@ export default function AccessRequestForm(props: IProps) {
           </ListItemIcon>
           <ListItemText id="allPorts" primary="All ports"/>
         </ListItem>
-        {state.allPorts ? null : sortedPorts.map((portCode) => {
-          return <ListItem
-            button
-            key={portCode}
-            onClick={() => updatePortSelection(portCode)}
-          >
-            <ListItemIcon>
-              <Checkbox
-                inputProps={{'aria-labelledby': portCode}}
-                name={portCode}
-                checked={state.portsRequested.includes(portCode)}
-              />
-            </ListItemIcon>
-            <ListItemText id={portCode} primary={portCode.toUpperCase()}/>
-          </ListItem>
-        })}
+        <ListItem alignItems='flex-start'>
+          {regions.map((region) => {
+            const sortedPorts = region.ports.sort()
+            return <Grid item xs={3} sx={{verticalAlign: 'top'}}>
+              <Region>{region.name}</Region>
+              <List sx={{verticalAlign: 'top'}}>
+                {sortedPorts.map((portCode) => {
+                  return <ListItem
+                    button
+                    key={portCode}
+                    onClick={() => updatePortSelection(portCode)}
+                    disablePadding={true}
+                  >
+                    <ListItemIcon>
+                      <Checkbox
+                        inputProps={{'aria-labelledby': portCode}}
+                        name={portCode}
+                        checked={state.portsRequested.includes(portCode)}
+                      />
+                    </ListItemIcon>
+                    <ListItemText id={portCode} primary={portCode.toUpperCase()}/>
+                  </ListItem>
+                })}
+              </List>
+            </Grid>
+          })}
+        </ListItem>
         <Divider/>
         <ListItem
           button
@@ -147,7 +184,7 @@ export default function AccessRequestForm(props: IProps) {
 
       </List>
       <ListItem>
-        <StyledPaper>
+        <Declaration>
           <StyledTypography>Declaration</StyledTypography>
           <Typography>I understand that:</Typography>
           <DeclarationUl>
@@ -160,7 +197,7 @@ export default function AccessRequestForm(props: IProps) {
               share any data
             </li>
           </DeclarationUl>
-        </StyledPaper>
+        </Declaration>
       </ListItem>
       <ListItem
         button
@@ -182,16 +219,16 @@ export default function AccessRequestForm(props: IProps) {
               color="primary">
         Request access
       </Button>
-    </div>;
+    </Box>;
   }
 
   return state.requestSubmitted ?
     <ThankYouBox>
-      <StyledPaper>
+      <Declaration>
         <h1>Thank you</h1>
         <p>You'll be notified by email when your request has been processed. This usually happens within a couple of
           hours, but may take longer outside core working hours (Monday to Friday, 9am to 5pm).</p>
-      </StyledPaper>
+      </Declaration>
     </ThankYouBox> :
     form(props.ports);
 }

--- a/react/src/components/AccessRequestForm.tsx
+++ b/react/src/components/AccessRequestForm.tsx
@@ -7,9 +7,8 @@ import ListItem from "@mui/material/ListItem";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import Checkbox from "@mui/material/Checkbox";
 import ListItemText from "@mui/material/ListItemText";
-import Divider from "@mui/material/Divider";
-import {Box, FormControl, Grid, TextField, Typography} from "@mui/material";
-import Button from "@mui/material/Button";
+import {Box, Button, Divider, FormControl, TextField, Typography} from "@mui/material";
+import {PortRegion} from "../model/Config";
 
 
 const Declaration = styled('div')(({theme}) => ({
@@ -32,12 +31,12 @@ const ThankYouBox = styled(Box)(() => ({
 }));
 
 interface IProps {
+  regions: PortRegion[];
   ports: string[];
   teamEmail: string;
 }
 
 interface IState {
-  allPorts: boolean;
   portsRequested: string[];
   staffing: boolean;
   lineManager: string;
@@ -45,43 +44,15 @@ interface IState {
   requestSubmitted: boolean;
 }
 
-const regions =
-  [
-    {
-      name: 'North',
-      ports: ["BFS", "BHD", "DSA", "EDI", "GLA", "HUY", "LBA", "LPL", "MAN", "MME", "NCL", "PIK"]
-    },
-    {
-      name: 'Central',
-      ports: ["BHX", "EMA", "LCY", "LTN", "NYI", "STN"]
-    },
-    {
-      name: 'South',
-      ports: ["BOH", "BRS", "CWL", "EXT", "LGW", "NQY", "SOU"]
-    },
-    {
-      name: 'Heathrow',
-      ports: ["LHR"]
-    }
-  ]
-
-const Region = styled('p')(() => ({
-  fontSize: '21px',
-  fontWeight: 'bold',
-}));
-
 export default function AccessRequestForm(props: IProps) {
   const [state, setState] = React.useState(
     {
-      allPorts: false,
       portsRequested: [],
       staffing: false,
       lineManager: "",
       agreeDeclaration: false,
       requestSubmitted: false,
     } as IState);
-
-  regions
 
   const updatePortSelection = (port: string) => {
     const requested: string[] = state.portsRequested.includes(port) ?
@@ -108,53 +79,91 @@ export default function AccessRequestForm(props: IProps) {
     .then(() => axios.get(ApiClient.logoutEndPoint))
     .then(() => console.log("User has been logged out."))
 
+  const allPorts = props.regions.map(r => r.ports).reduce((a, b) => a.concat(b))
+  const allPortsCount = props.regions.reduce((a, b) => a + b.ports.length, 0)
 
-  function form(portsAvailable: string[]) {
-    portsAvailable
-    // const sortedPorts = [...portsAvailable].sort()
+  function form() {
+    const allPortsSelected = state.portsRequested.length === allPortsCount
     return <Box sx={{width: '100%'}}>
       <h1>Welcome to DRT</h1>
       <p>Please select the ports you require access to</p>
       <List>
         <ListItem
           button
-          key={'allStaff'}
-          onClick={() => setState({...state, allPorts: !state.allPorts})}>
+          key={'allPorts'}
+          onClick={() => {
+            if (!allPortsSelected) setState({...state, portsRequested: allPorts})
+            else setState({...state, portsRequested: []})
+          }}>
           <ListItemIcon>
             <Checkbox
               inputProps={{'aria-labelledby': "allPorts"}}
               name="allPorts"
-              checked={state.allPorts}
+              checked={state.portsRequested.length === allPortsCount}
+              indeterminate={state.portsRequested.length > 0 && state.portsRequested.length < allPortsCount}
             />
           </ListItemIcon>
-          <ListItemText id="allPorts" primary="All ports"/>
+          <ListItemText id="allPorts" primary="All Regions" sx={{
+            fontSize: '21px',
+            fontWeight: 'bold',
+          }}/>
         </ListItem>
         <ListItem alignItems='flex-start'>
-          {regions.map((region) => {
-            const sortedPorts = region.ports.sort()
-            return <Grid item xs={3} sx={{verticalAlign: 'top'}}>
-              <Region>{region.name}</Region>
-              <List sx={{verticalAlign: 'top'}}>
-                {sortedPorts.map((portCode) => {
-                  return <ListItem
-                    button
-                    key={portCode}
-                    onClick={() => updatePortSelection(portCode)}
+          <Box sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'space-start',
+          }}>
+            {props.regions.map((region) => {
+              const sortedPorts = [...region.ports].sort()
+              const regionSelected = sortedPorts.every(p => state.portsRequested.includes(p))
+              const regionPartiallySelected = sortedPorts.some(p => state.portsRequested.includes(p)) && !regionSelected
+
+              function toggleRegionPorts() {
+                if (!regionSelected) setState({...state, portsRequested: state.portsRequested.concat(sortedPorts)})
+                else setState({...state, portsRequested: state.portsRequested.filter(p => !sortedPorts.includes(p))})
+              }
+
+              return <Box sx={{
+                minWidth: '200px',
+                marginRight: '50px'
+              }}>
+                <List sx={{verticalAlign: 'top'}}>
+                  <ListItem
+                    onClick={() => toggleRegionPorts()}
                     disablePadding={true}
                   >
                     <ListItemIcon>
                       <Checkbox
-                        inputProps={{'aria-labelledby': portCode}}
-                        name={portCode}
-                        checked={state.portsRequested.includes(portCode)}
+                        inputProps={{'aria-labelledby': region.name}}
+                        name={region.name}
+                        checked={regionSelected}
+                        indeterminate={regionPartiallySelected}
                       />
                     </ListItemIcon>
-                    <ListItemText id={portCode} primary={portCode.toUpperCase()}/>
+                    <ListItemText sx={{fontWeight: 'bold'}} primary={region.name}>{region.name}</ListItemText>
                   </ListItem>
-                })}
-              </List>
-            </Grid>
-          })}
+                  {sortedPorts.map((portCode) => {
+                    return <ListItem
+                      button
+                      key={portCode}
+                      onClick={() => updatePortSelection(portCode)}
+                      disablePadding={true}
+                    >
+                      <ListItemIcon>
+                        <Checkbox
+                          inputProps={{'aria-labelledby': portCode}}
+                          name={portCode}
+                          checked={state.portsRequested.includes(portCode)}
+                        />
+                      </ListItemIcon>
+                      <ListItemText id={portCode} primary={portCode.toUpperCase()}/>
+                    </ListItem>
+                  })}
+                </List>
+              </Box>
+            })}
+          </Box>
         </ListItem>
         <Divider/>
         <ListItem
@@ -213,10 +222,12 @@ export default function AccessRequestForm(props: IProps) {
         <ListItemText id="agreeDeclaration" primary="I understand and agree with the above declarations"/>
       </ListItem>
 
-      <Button disabled={(state.portsRequested.length === 0 && !state.allPorts) || !state.agreeDeclaration}
-              onClick={save}
-              variant="contained"
-              color="primary">
+      <Button
+        disabled={(state.portsRequested.length === 0) || !state.agreeDeclaration}
+        onClick={save}
+        variant="contained"
+        color="primary"
+      >
         Request access
       </Button>
     </Box>;
@@ -226,9 +237,10 @@ export default function AccessRequestForm(props: IProps) {
     <ThankYouBox>
       <Declaration>
         <h1>Thank you</h1>
-        <p>You'll be notified by email when your request has been processed. This usually happens within a couple of
+        <p>You'll be notified by email when your request has been processed. This usually happens within a couple
+          of
           hours, but may take longer outside core working hours (Monday to Friday, 9am to 5pm).</p>
       </Declaration>
     </ThankYouBox> :
-    form(props.ports);
+    form();
 }

--- a/react/src/components/AccessRequestForm.tsx
+++ b/react/src/components/AccessRequestForm.tsx
@@ -103,10 +103,9 @@ export default function AccessRequestForm(props: IProps) {
               indeterminate={state.portsRequested.length > 0 && state.portsRequested.length < allPortsCount}
             />
           </ListItemIcon>
-          <ListItemText id="allPorts" primary="All Regions" sx={{
-            fontSize: '21px',
-            fontWeight: 'bold',
-          }}/>
+          <ListItemText id="allPorts">
+            <Box sx={{fontWeight: 'bold'}}>All regions</Box>
+          </ListItemText>
         </ListItem>
         <ListItem alignItems='flex-start'>
           <Box sx={{
@@ -130,7 +129,9 @@ export default function AccessRequestForm(props: IProps) {
               }}>
                 <List sx={{verticalAlign: 'top'}}>
                   <ListItem
+                    button
                     onClick={() => toggleRegionPorts()}
+                    key={region.name}
                     disablePadding={true}
                   >
                     <ListItemIcon>
@@ -141,7 +142,9 @@ export default function AccessRequestForm(props: IProps) {
                         indeterminate={regionPartiallySelected}
                       />
                     </ListItemIcon>
-                    <ListItemText sx={{fontWeight: 'bold'}} primary={region.name}>{region.name}</ListItemText>
+                    <ListItemText>
+                      <Box sx={{fontWeight: 'bold'}}>{region.name}</Box>
+                    </ListItemText>
                   </ListItem>
                   {sortedPorts.map((portCode) => {
                     return <ListItem

--- a/react/src/components/Home.tsx
+++ b/react/src/components/Home.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import AccessRequestForm from "./AccessRequestForm";
-import PortList from "./PortList";
+import {PortList} from "./PortList";
 import {Box} from "@mui/material";
 import {UserProfile} from "../model/User";
 import {ConfigValues} from "../model/Config";

--- a/react/src/components/Home.tsx
+++ b/react/src/components/Home.tsx
@@ -12,11 +12,11 @@ interface IProps {
   config: ConfigValues;
 }
 
-export default function Home(props: IProps) {
+export const Home = (props: IProps) => {
   return <Box className="App-header">
     {props.user.ports.length === 0 ?
-      <AccessRequestForm ports={props.config.ports} teamEmail={props.config.teamEmail}/> :
-      <PortList ports={props.user.ports} drtDomain={props.config.domain}/>
+      <AccessRequestForm regions={props.config.regions} ports={props.config.ports} teamEmail={props.config.teamEmail}/> :
+      <PortList allRegions={props.config.regions} userPorts={props.user.ports} drtDomain={props.config.domain}/>
     }
   </Box>
 }

--- a/react/src/components/Home.tsx
+++ b/react/src/components/Home.tsx
@@ -15,7 +15,7 @@ interface IProps {
 export const Home = (props: IProps) => {
   return <Box className="App-header">
     {props.user.ports.length === 0 ?
-      <AccessRequestForm regions={props.config.regions} ports={props.config.ports} teamEmail={props.config.teamEmail}/> :
+      <AccessRequestForm regions={props.config.regions} teamEmail={props.config.teamEmail}/> :
       <PortList allRegions={props.config.regions} userPorts={props.user.ports} drtDomain={props.config.domain}/>
     }
   </Box>

--- a/react/src/components/Navigation.tsx
+++ b/react/src/components/Navigation.tsx
@@ -32,6 +32,7 @@ export default function Navigation(props: IProps) {
         aria-haspopup="true"
         variant={"contained"}
         onClick={handleClick}
+        sx={{marginTop: '0px'}}
       >
         Menu
       </TriggerButton>

--- a/react/src/components/PortList.tsx
+++ b/react/src/components/PortList.tsx
@@ -5,6 +5,8 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import Icon from "@mui/icons-material/FlightLand";
 import ListItemText from "@mui/material/ListItemText";
 import Divider from "@mui/material/Divider";
+import {Box, Grid} from "@mui/material";
+import {styled} from "@mui/material/styles";
 
 
 interface IProps {
@@ -12,25 +14,58 @@ interface IProps {
   drtDomain: string;
 }
 
-export default class PortList extends React.Component<IProps> {
-  render() {
-    const sortedPorts = [...this.props.ports].sort()
-    return <div>
-      <h1>Welcome to DRT</h1>
-      <p>Select your destination</p>
-      <List>
-        {sortedPorts.map((portCode) => {
-          let portCodeLC = portCode.toLowerCase();
-          const url = 'https://' + portCodeLC + '.' + this.props.drtDomain;
-          return <div key={portCode}>
-            <ListItem button component="a" href={url} id={"port-link-" + portCodeLC}>
-              <ListItemIcon><Icon/></ListItemIcon>
-              <ListItemText primary={portCode.toUpperCase()}/>
-            </ListItem>
-            <Divider variant="inset" component="li"/>
-          </div>
-        })}
-      </List>
-    </div>
-  }
+const Region = styled('p')(() => ({
+  fontSize: '21px',
+  fontWeight: 'bold',
+}));
+
+
+export const PortList = (props: IProps) => {
+  const regions =
+    [
+      {
+        name: 'North',
+        ports: ["BFS", "BHD", "DSA", "EDI", "GLA", "HUY", "LBA", "LPL", "MAN", "MME", "NCL", "PIK"]
+      },
+      {
+        name: 'Central',
+        ports: ["BHX", "EMA", "LCY", "LTN", "NYI", "STN"]
+      },
+      {
+        name: 'South',
+        ports: ["BOH", "BRS", "CWL", "EXT", "LGW", "NQY", "SOU"]
+      },
+      {
+        name: 'Heathrow',
+        ports: ["LHR"]
+      }
+    ]
+
+  return <Box sx={{width: '100%'}}>
+    <h1>Welcome to DRT</h1>
+    <p>Select your destination</p>
+    <Grid container spacing={2}>
+      {regions.map((region) => {
+        const sortedPorts = region.ports.sort()
+        return <Grid item xs={3}>
+          <Region>{region.name}</Region>
+          <List>
+            {sortedPorts.map((portCode) => {
+              let portCodeLC = portCode.toLowerCase();
+              const url = 'https://' + portCodeLC + '.' + props.drtDomain;
+              return <div key={portCode}>
+                <ListItem button component="a" href={url} id={"port-link-" + portCodeLC}>
+                  <ListItemIcon><Icon/></ListItemIcon>
+                  <ListItemText primary={portCode.toUpperCase()}/>
+                </ListItem>
+                <Divider variant="inset" component="li"/>
+              </div>
+            })}
+          </List>
+        </Grid>
+      })}
+    </Grid>
+
+  </Box>
+
 }

--- a/react/src/components/PortList.tsx
+++ b/react/src/components/PortList.tsx
@@ -1,71 +1,29 @@
 import React from "react";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
-import ListItemIcon from "@mui/material/ListItemIcon";
-import Icon from "@mui/icons-material/FlightLand";
-import ListItemText from "@mui/material/ListItemText";
-import Divider from "@mui/material/Divider";
-import {Box, Grid} from "@mui/material";
-import {styled} from "@mui/material/styles";
+import {Box} from "@mui/material";
+import {PortRegion} from "../model/Config";
+import {PortListStraight} from "./PortListStraight";
+import {PortListByRegion} from "./PortListByRegion";
 
 
 interface IProps {
-  ports: string[];
+  allRegions: PortRegion[]
+  userPorts: string[];
   drtDomain: string;
 }
 
-const Region = styled('p')(() => ({
-  fontSize: '21px',
-  fontWeight: 'bold',
-}));
-
-
 export const PortList = (props: IProps) => {
-  const regions =
-    [
-      {
-        name: 'North',
-        ports: ["BFS", "BHD", "DSA", "EDI", "GLA", "HUY", "LBA", "LPL", "MAN", "MME", "NCL", "PIK"]
-      },
-      {
-        name: 'Central',
-        ports: ["BHX", "EMA", "LCY", "LTN", "NYI", "STN"]
-      },
-      {
-        name: 'South',
-        ports: ["BOH", "BRS", "CWL", "EXT", "LGW", "NQY", "SOU"]
-      },
-      {
-        name: 'Heathrow',
-        ports: ["LHR"]
-      }
-    ]
+  const userRegions: PortRegion[] = props.allRegions.map(region => {
+    const userPorts: string[] = props.userPorts.filter(p => region.ports.includes(p));
+    return {...region, ports: userPorts} as PortRegion
+  }).filter(r => r.ports.length > 0)
 
   return <Box sx={{width: '100%'}}>
     <h1>Welcome to DRT</h1>
     <p>Select your destination</p>
-    <Grid container spacing={2}>
-      {regions.map((region) => {
-        const sortedPorts = region.ports.sort()
-        return <Grid item xs={3}>
-          <Region>{region.name}</Region>
-          <List>
-            {sortedPorts.map((portCode) => {
-              let portCodeLC = portCode.toLowerCase();
-              const url = 'https://' + portCodeLC + '.' + props.drtDomain;
-              return <div key={portCode}>
-                <ListItem button component="a" href={url} id={"port-link-" + portCodeLC}>
-                  <ListItemIcon><Icon/></ListItemIcon>
-                  <ListItemText primary={portCode.toUpperCase()}/>
-                </ListItem>
-                <Divider variant="inset" component="li"/>
-              </div>
-            })}
-          </List>
-        </Grid>
-      })}
-    </Grid>
-
+    {userRegions.length > 1 ?
+      <PortListByRegion regions={userRegions} drtDomain={props.drtDomain}/> :
+      <PortListStraight ports={props.userPorts} drtDomain={props.drtDomain}/>
+    }
   </Box>
-
 }
+

--- a/react/src/components/PortListByRegion.tsx
+++ b/react/src/components/PortListByRegion.tsx
@@ -1,0 +1,47 @@
+import {styled} from "@mui/material/styles";
+import {PortRegion} from "../model/Config";
+import {Box} from "@mui/material";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import Icon from "@mui/icons-material/FlightLand";
+import ListItemText from "@mui/material/ListItemText";
+import Divider from "@mui/material/Divider";
+import React from "react";
+
+const Region = styled('p')(() => ({
+  fontSize: '21px',
+  fontWeight: 'bold',
+}));
+
+export const PortListByRegion = (props: { regions: PortRegion[], drtDomain: string }) => {
+  return <Box sx={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'space-start',
+    }}
+  >
+    {props.regions.map((region) => {
+      const sortedPorts = region.ports.sort()
+      return <Box sx={{
+        minWidth: '200px',
+        marginRight: '50px'
+      }}>
+        <Region>{region.name}</Region>
+        <List>
+          {sortedPorts.map((portCode) => {
+            let portCodeLC = portCode.toLowerCase();
+            const url = 'https://' + portCodeLC + '.' + props.drtDomain;
+            return <Box key={portCode}>
+              <ListItem button component="a" href={url} id={"port-link-" + portCodeLC}>
+                <ListItemIcon><Icon/></ListItemIcon>
+                <ListItemText primary={portCode.toUpperCase()}/>
+              </ListItem>
+              <Divider variant="inset" component="li"/>
+            </Box>
+          })}
+        </List>
+      </Box>
+    })}
+  </Box>
+}

--- a/react/src/components/PortListStraight.tsx
+++ b/react/src/components/PortListStraight.tsx
@@ -1,0 +1,28 @@
+import {Box} from "@mui/material";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import Icon from "@mui/icons-material/FlightLand";
+import ListItemText from "@mui/material/ListItemText";
+import Divider from "@mui/material/Divider";
+import React from "react";
+
+export const PortListStraight = (props: { ports: string[], drtDomain: string }) => {
+  const sortedPorts = [...props.ports].sort()
+
+  return <Box>
+    <List>
+      {sortedPorts.map((portCode) => {
+        let portCodeLC = portCode.toLowerCase();
+        const url = 'https://' + portCodeLC + '.' + props.drtDomain;
+        return <Box key={portCode}>
+          <ListItem button component="a" href={url} id={"port-link-" + portCodeLC}>
+            <ListItemIcon><Icon/></ListItemIcon>
+            <ListItemText primary={portCode.toUpperCase()}/>
+          </ListItem>
+          <Divider variant="inset" component="li"/>
+        </Box>
+      })}
+    </List>
+  </Box>
+}

--- a/react/src/model/Config.ts
+++ b/react/src/model/Config.ts
@@ -1,17 +1,16 @@
-
 export type PendingConfig = {
-    kind: "PendingConfig"
+  kind: "PendingConfig"
 }
 
 export type LoadedConfig = {
-    kind: "LoadedConfig"
-    values: ConfigValues
+  kind: "LoadedConfig"
+  values: ConfigValues
 }
 
 export type ConfigValues = {
-    ports: string[];
-    domain: string;
-    teamEmail: string;
+  ports: string[];
+  domain: string;
+  teamEmail: string;
 }
 
 export type Config = PendingConfig | LoadedConfig

--- a/react/src/model/Config.ts
+++ b/react/src/model/Config.ts
@@ -14,7 +14,6 @@ export type PortRegion = {
 
 export type ConfigValues = {
   regions: PortRegion[];
-  ports: string[];
   domain: string;
   teamEmail: string;
 }

--- a/react/src/model/Config.ts
+++ b/react/src/model/Config.ts
@@ -7,7 +7,13 @@ export type LoadedConfig = {
   values: ConfigValues
 }
 
+export type PortRegion = {
+  name: string
+  ports: string[]
+}
+
 export type ConfigValues = {
+  regions: PortRegion[];
   ports: string[];
   domain: string;
   teamEmail: string;

--- a/src/main/scala/uk/gov/homeoffice/drt/ClientConfig.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/ClientConfig.scala
@@ -1,0 +1,20 @@
+package uk.gov.homeoffice.drt
+
+import spray.json.{DefaultJsonProtocol, JsObject, JsValue, RootJsonFormat, enrichAny}
+import uk.gov.homeoffice.drt.ports.PortRegion
+
+case class ClientConfig(portsByRegion: Iterable[PortRegion], domain: String, teamEmail: String)
+
+trait ClientConfigJsonFormats extends DefaultJsonProtocol {
+  implicit object PortRegionJsonFormat extends RootJsonFormat[PortRegion] {
+    override def read(json: JsValue): PortRegion = throw new Exception("PortRegion deserialisation not yet implemented")
+
+    override def write(obj: PortRegion): JsValue = JsObject(Map(
+      "name" -> obj.name.toJson,
+      "ports" -> obj.ports.map(_.iata).toJson,
+    )
+    )
+  }
+
+  implicit val clientConfigJsonFormat: RootJsonFormat[ClientConfig] = jsonFormat3(ClientConfig.apply)
+}

--- a/src/main/scala/uk/gov/homeoffice/drt/DrtDashboardApp.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/DrtDashboardApp.scala
@@ -3,6 +3,7 @@ package uk.gov.homeoffice.drt
 import akka.actor.typed.ActorSystem
 import com.typesafe.config.ConfigFactory
 import uk.gov.homeoffice.drt.Server.ServerConfig
+import uk.gov.homeoffice.drt.ports.PortRegion
 
 object DrtDashboardApp extends App {
   val config = ConfigFactory.load()
@@ -11,7 +12,7 @@ object DrtDashboardApp extends App {
     host = config.getString("server.host"),
     port = config.getInt("server.port"),
     teamEmail = config.getString("dashboard.team-email"),
-    portCodes = config.getString("dashboard.port-codes").split(","),
+    portRegions = PortRegion.regions,
     ciriumDataUri = config.getString("cirium.data-uri"),
     rootDomain = config.getString("drt.domain"),
     useHttps = config.getBoolean("drt.use-https"),

--- a/src/main/scala/uk/gov/homeoffice/drt/JsonSupport.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/JsonSupport.scala
@@ -1,14 +1,10 @@
 package uk.gov.homeoffice.drt
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import spray.json.{ DefaultJsonProtocol, RootJsonFormat }
-import uk.gov.homeoffice.drt.alerts.Alert
-import uk.gov.homeoffice.drt.routes.{ FeedStatus, FlightData, PortAlerts }
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+import uk.gov.homeoffice.drt.routes.{FeedStatus, FlightData}
 
 trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
-
   implicit val flightDataFormat: RootJsonFormat[FlightData] = jsonFormat7(FlightData)
-
   implicit val feedStatusFormat: RootJsonFormat[FeedStatus] = jsonFormat3(FeedStatus)
-
 }

--- a/src/main/scala/uk/gov/homeoffice/drt/authentication/User.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/authentication/User.scala
@@ -20,7 +20,7 @@ object User {
     User(email, roles.split(",").flatMap(Roles.parse).toSet)
 }
 
-object UserJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+trait UserJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit object RoleFormatParser extends RootJsonFormat[Role] {
     override def write(obj: Role): JsValue = JsObject(Map("name" -> JsString(obj.name)))
@@ -49,11 +49,10 @@ object UserJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
         }
     }
   }
-
 }
 
 case class AccessRequest(portsRequested: Set[String], allPorts: Boolean, staffing: Boolean, lineManager: String, agreeDeclaration: Boolean)
 
-object AccessRequestJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+trait AccessRequestJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val AccessRequestFormatParser: RootJsonFormat[AccessRequest] = jsonFormat5(AccessRequest)
 }

--- a/src/main/scala/uk/gov/homeoffice/drt/json/PortRegionJsonFormats.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/json/PortRegionJsonFormats.scala
@@ -1,0 +1,14 @@
+package uk.gov.homeoffice.drt.json
+
+import spray.json.{ DefaultJsonProtocol, JsArray, JsObject, JsString, JsValue, RootJsonFormat, enrichAny }
+import uk.gov.homeoffice.drt.ports.PortRegion
+
+object PortRegionJsonFormats extends DefaultJsonProtocol {
+  implicit object PortRegionJsonFormat extends RootJsonFormat[PortRegion] {
+    override def read(json: JsValue): PortRegion = throw new Exception("Deserialising PortRegion not implemented yet")
+
+    override def write(obj: PortRegion): JsValue = JsObject(Map(
+      "name" -> obj.name.toJson,
+      "ports" -> JsArray(obj.ports.map(pc => JsString(pc.iata)).toVector)))
+  }
+}

--- a/src/main/scala/uk/gov/homeoffice/drt/redlist/RedListJsonFormats.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/redlist/RedListJsonFormats.scala
@@ -3,7 +3,6 @@ package uk.gov.homeoffice.drt.redlist
 import spray.json.{ DefaultJsonProtocol, JsArray, JsNumber, JsObject, JsString, JsValue, RootJsonFormat, enrichAny }
 
 object RedListJsonFormats extends DefaultJsonProtocol {
-
   implicit object redListUpdateJsonFormat extends RootJsonFormat[RedListUpdate] {
     override def write(obj: RedListUpdate): JsValue = JsObject(Map(
       "effectiveFrom" -> JsNumber(obj.effectiveFrom),

--- a/src/main/scala/uk/gov/homeoffice/drt/redlist/RedListJsonFormats.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/redlist/RedListJsonFormats.scala
@@ -2,7 +2,7 @@ package uk.gov.homeoffice.drt.redlist
 
 import spray.json.{ DefaultJsonProtocol, JsArray, JsNumber, JsObject, JsString, JsValue, RootJsonFormat, enrichAny }
 
-object RedListJsonFormats extends DefaultJsonProtocol {
+trait RedListJsonFormats extends DefaultJsonProtocol {
   implicit object redListUpdateJsonFormat extends RootJsonFormat[RedListUpdate] {
     override def write(obj: RedListUpdate): JsValue = JsObject(Map(
       "effectiveFrom" -> JsNumber(obj.effectiveFrom),

--- a/src/main/scala/uk/gov/homeoffice/drt/routes/ApiRoutes.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/routes/ApiRoutes.scala
@@ -8,12 +8,13 @@ import akka.http.scaladsl.server.directives.MethodDirectives.get
 import akka.http.scaladsl.server.{ Directive0, Route }
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import org.slf4j.{ Logger, LoggerFactory }
-import spray.json.{ JsArray, JsObject, JsString, enrichAny }
+import spray.json._
 import uk.gov.homeoffice.drt.alerts.{ Alert, MultiPortAlert, MultiPortAlertClient }
 import uk.gov.homeoffice.drt.auth.Roles
 import uk.gov.homeoffice.drt.auth.Roles._
 import uk.gov.homeoffice.drt.authentication.{ AccessRequest, User }
 import uk.gov.homeoffice.drt.notifications.EmailNotifications
+import uk.gov.homeoffice.drt.ports.PortRegion
 import uk.gov.homeoffice.drt.redlist.{ RedListJsonFormats, RedListUpdate, RedListUpdates, SetRedListUpdate }
 import uk.gov.homeoffice.drt.{ Dashboard, DashboardClient }
 
@@ -57,7 +58,9 @@ object ApiRoutes {
         (get & path("config")) {
           headerValueByName("X-Auth-Roles") { _ =>
             import uk.gov.homeoffice.drt.authentication.UserJsonSupport._
+            import uk.gov.homeoffice.drt.json.PortRegionJsonFormats._
             val json = JsObject(Map(
+              "regions" -> JsArray(PortRegion.regions.map(_.toJson).toVector),
               "ports" -> JsArray(portCodes.map(JsString(_)).toVector),
               "domain" -> JsString(domain),
               "teamEmail" -> JsString(teamEmail)))

--- a/src/main/scala/uk/gov/homeoffice/drt/routes/DrtRoutes.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/routes/DrtRoutes.scala
@@ -11,6 +11,7 @@ import akka.stream.Materializer
 import org.slf4j.{ Logger, LoggerFactory }
 import uk.gov.homeoffice.drt.auth.Roles
 import uk.gov.homeoffice.drt.pages.{ Drt, Layout }
+import uk.gov.homeoffice.drt.ports.PortRegion
 import uk.gov.homeoffice.drt.services.drt.FeedJsonSupport._
 import uk.gov.homeoffice.drt.services.drt.{ DashboardPortStatus, FeedSourceStatus }
 import uk.gov.homeoffice.drt.{ Dashboard, DashboardClient }
@@ -20,7 +21,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 object DrtRoutes {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
-  def apply(prefix: String, portCodes: Array[String])(implicit system: ClassicActorSystemProvider, mat: Materializer, ec: ExecutionContext): Route = pathPrefix(prefix) {
+  def apply(prefix: String, portCodes: Iterable[String])(implicit system: ClassicActorSystemProvider, mat: Materializer, ec: ExecutionContext): Route = pathPrefix(prefix) {
     get {
       complete {
         eventualPortsWithStatuses(portCodes)
@@ -29,7 +30,7 @@ object DrtRoutes {
     }
   }
 
-  private def eventualPortsWithStatuses(portCodes: Array[String])(implicit system: ClassicActorSystemProvider, mat: Materializer, ec: ExecutionContext): Future[List[DashboardPortStatus]] =
+  private def eventualPortsWithStatuses(portCodes: Iterable[String])(implicit system: ClassicActorSystemProvider, mat: Materializer, ec: ExecutionContext): Future[List[DashboardPortStatus]] =
     Future
       .sequence(portCodes.map(eventualPortFeedStatuses).toList)
       .recover {

--- a/src/test/scala/uk/gov/homeoffice/drt/authentication/AccessRequestSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/drt/authentication/AccessRequestSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.testkit.Specs2RouteTest
 import org.specs2.mutable.Specification
 import spray.json._
 
-class AccessRequestSpec extends Specification with Specs2RouteTest {
+class AccessRequestSpec extends Specification with Specs2RouteTest with AccessRequestJsonSupport {
   "Given a json object string I should be able to parse it to an AccessRequest" >> {
     val string =
       """
@@ -19,7 +19,7 @@ class AccessRequestSpec extends Specification with Specs2RouteTest {
         |    "agreeDeclaration": true
         |}
         |""".stripMargin
-    import AccessRequestJsonSupport._
+
     val request = string.parseJson.convertTo[AccessRequest]
 
     val expected = AccessRequest(

--- a/src/test/scala/uk/gov/homeoffice/drt/redlist/RedListUpdatesSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/drt/redlist/RedListUpdatesSpec.scala
@@ -1,18 +1,14 @@
 package uk.gov.homeoffice.drt.redlist
 
 import org.specs2.mutable.Specification
-import spray.json.DefaultJsonProtocol.{ LongJsonFormat, listFormat, mapFormat, seqFormat }
 
-class RedListUpdatesSpec extends Specification {
+class RedListUpdatesSpec extends Specification with RedListJsonFormats {
 
-  implicit val rdu = RedListJsonFormats.redListUpdateJsonFormat
-  implicit val rdus = RedListJsonFormats.redListUpdatesJsonFormat
-  implicit val srdu = RedListJsonFormats.setRedListUpdatesJsonFormat
   import spray.json._
 
   val dateMillis = 1631228400000L
 
-  val setRedListUpdatesJsonStr =
+  val setRedListUpdatesJsonStr: String =
     s"""{
        |  "originalDate":$dateMillis,
        |  "redListUpdate":{


### PR DESCRIPTION
Display port list by region on homepage when user has access to ports in multiple regions
Display port lists by region on signup page 
 - Allow easy selection of all ports a region
 - Allow easy selection of all ports in the UK
Clean up header layout
Use flexing layout for regions that wrap with smaller screens