### PR TITLE
Drtii 1246 regional export missing arrivals

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,4 @@
 dashboard {
-  port-codes = ${PORT_CODES}
-
   notifications {
     gov-notify-api-key = ${GOV_NOTIFY_API_KEY}
     access-request-emails = ${ACCESS_REQUEST_EMAIL}

--- a/src/main/scala/uk/gov/homeoffice/drt/Dashboard.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/Dashboard.scala
@@ -126,6 +126,6 @@ object Dashboard {
 
   def timeSince(millis: Long): Long = System.currentTimeMillis() - millis
 
-  def drtUriForPortCode(portCode: String): String = s"http://${portCode.toLowerCase}:9000"
+  def drtInternalUriForPortCode(portCode: String): String = s"http://${portCode.toLowerCase}:9000"
 
 }

--- a/src/main/scala/uk/gov/homeoffice/drt/alerts/MultiPortAlert.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/alerts/MultiPortAlert.scala
@@ -49,7 +49,7 @@ object MultiPortAlertClient extends MultiPortAlertJsonSupport {
       case (portCode, alert) =>
         log.info("Sending new alert to ${Dashboard.drtUriForPortCode(portCode)}/alerts")
         DashboardClient.postWithRoles(
-          s"${Dashboard.drtUriForPortCode(portCode)}/alerts",
+          s"${Dashboard.drtInternalUriForPortCode(portCode)}/alerts",
           alert.toJson.toString(),
           user.roles)
     }

--- a/src/main/scala/uk/gov/homeoffice/drt/rccu/ExportCsvService.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/rccu/ExportCsvService.scala
@@ -3,15 +3,13 @@ package uk.gov.homeoffice.drt.rccu
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.StatusCodes.OK
 import akka.stream.Materializer
-import org.joda.time.{ DateTime, DateTimeZone }
+import org.joda.time.{DateTime, DateTimeZone}
 import org.joda.time.format.DateTimeFormat
-import org.slf4j.{ Logger, LoggerFactory }
+import org.slf4j.{Logger, LoggerFactory}
 import uk.gov.homeoffice.drt.ports.PortRegion
-import uk.gov.homeoffice.drt.{ Dashboard, HttpClient }
+import uk.gov.homeoffice.drt.{Dashboard, HttpClient}
 
-import scala.concurrent.{ ExecutionContextExecutor, Future }
-
-case class PortResponse(port: String, regionName: String, terminal: String, httpResponse: HttpResponse)
+import scala.concurrent.{ExecutionContextExecutor, Future}
 
 class ExportCsvService(httpClient: HttpClient) {
 
@@ -25,22 +23,33 @@ class ExportCsvService(httpClient: HttpClient) {
     s"${Dashboard.drtInternalUriForPortCode(portCode)}/$drtExportCsvRoutePath/$start/$end/$terminal"
 
   def getPortResponseForTerminal(start: String, end: String, regionName: String, port: String, terminal: String)
-                                (implicit executionContext: ExecutionContextExecutor, mat: Materializer): Future[Option[PortResponse]] = {
+                                (implicit executionContext: ExecutionContextExecutor, mat: Materializer): Future[String] = {
     val uri = getUri(port, start, end, terminal)
     val httpRequest = httpClient.createPortArrivalImportRequest(uri, port)
-    httpClient.send(httpRequest)
-      .map { r =>
-        if (r.status == OK)
-          Some(PortResponse(port, regionName, terminal, r))
-        else {
+    httpClient
+      .send(httpRequest)
+      .flatMap { r =>
+        if (r.status == OK) {
+          r.entity.dataBytes
+            .runReduce(_ ++ _)
+            .map {
+              _
+                .utf8String
+                .split("\n")
+                .filterNot(_.contains("ICAO"))
+                .map(line => s"${regionName},$port,$terminal,$line")
+                .mkString("\n")
+            }
+        } else {
+          r.entity.discardBytes()
           log.warn(s"Not OK response $r")
-          None
+          Future.successful("")
         }
       }.recoverWith {
-        case e: Throwable =>
-          log.error(s"Error while requesting drt for $uri", e)
-          Future.successful(None)
-      }
+      case e: Throwable =>
+        log.error(s"Error while requesting drt for $uri", e)
+        Future.successful("")
+    }
   }
 
   val formattedStringDate: DateTime => String = dateTime => DateTimeFormat.forPattern("yyyyMMddHHmmss").print(dateTime)

--- a/src/main/scala/uk/gov/homeoffice/drt/rccu/ExportCsvService.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/rccu/ExportCsvService.scala
@@ -22,7 +22,7 @@ class ExportCsvService(httpClient: HttpClient) {
   def getPortRegion(region: String) = PortRegion.regions.find(_.name == region)
 
   def getUri(portCode: String, start: String, end: String, terminal: String): String =
-    s"${Dashboard.drtUriForPortCode(portCode)}/$drtExportCsvRoutePath/$start/$end/$terminal"
+    s"${Dashboard.drtInternalUriForPortCode(portCode)}/$drtExportCsvRoutePath/$start/$end/$terminal"
 
   def getPortResponseForTerminal(start: String, end: String, regionName: String, port: String, terminal: String)
                                 (implicit executionContext: ExecutionContextExecutor, mat: Materializer): Future[Option[PortResponse]] = {

--- a/src/main/scala/uk/gov/homeoffice/drt/routes/DrtRoutes.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/routes/DrtRoutes.scala
@@ -40,7 +40,7 @@ object DrtRoutes {
       }
 
   private def eventualPortFeedStatuses(pc: String)(implicit system: ClassicActorSystemProvider, mat: Materializer, ec: ExecutionContext): Future[DashboardPortStatus] = {
-    val portFeedStatusUri = Dashboard.drtUriForPortCode(pc) + "/feed-statuses"
+    val portFeedStatusUri = Dashboard.drtInternalUriForPortCode(pc) + "/feed-statuses"
     DashboardClient.getWithRoles(portFeedStatusUri, Roles.parse(pc.toUpperCase).toList)
       .flatMap(res => Unmarshal[HttpEntity](res.entity.withContentType(ContentTypes.`application/json`))
         .to[List[FeedSourceStatus]]

--- a/src/main/scala/uk/gov/homeoffice/drt/routes/ExportRoutes.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/routes/ExportRoutes.scala
@@ -40,14 +40,15 @@ object ExportRoutes {
               case Some(PortResponse(port, region, terminal, httpResponse)) =>
                 httpResponse.entity.dataBytes
                   .runReduce(_ ++ _)
-                  .map {
-                    _
-                      .utf8String
-                      .split("\n")
-                      .filterNot(_.contains("ICAO"))
-                      .map(line => s"${region.name},$port,$terminal,$line")
-                      .mkString("\n")
-                  }
+                  .map(_.utf8String)
+              //                  .map {
+              //                    _
+              //                      .utf8String
+              //                      .split("\n")
+              //                      .filterNot(_.contains("ICAO"))
+              //                      .map(line => s"${region.name},$port,$terminal,$line")
+              //                      .mkString("\n")
+              //                  }
             }
             .prepend(Source.single(ArrivalExportHeadings.regionalExportHeadings))
           complete(stream)

--- a/src/main/scala/uk/gov/homeoffice/drt/routes/NeboUploadRoutes.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/routes/NeboUploadRoutes.scala
@@ -88,7 +88,7 @@ case class NeboUploadRoutes(neboPortCodes: List[String], httpClient: HttpClient)
     }
 
   def sendFlightDataToPort(flightData: List[FlightData], portCode: String, httpClient: HttpClient)(implicit ec: ExecutionContextExecutor, mat: Materializer): Future[FeedStatus] = {
-    val httpRequest = httpClient.createDrtNeboRequest(flightData, s"${drtUriForPortCode(portCode)}$drtRoutePath", Roles.parse(portCode))
+    val httpRequest = httpClient.createDrtNeboRequest(flightData, s"${drtInternalUriForPortCode(portCode)}$drtRoutePath", Roles.parse(portCode))
     httpClient.send(httpRequest)
       .map(r => FeedStatus(portCode, flightData.size, r.status.toString()))
   }

--- a/src/test/scala/uk/gov/homeoffice/drt/DrtPortDashboardSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/drt/DrtPortDashboardSpec.scala
@@ -29,7 +29,7 @@ class DrtPortDashboardSpec extends TestKit(ActorSystem("testActorSystem", Config
 
       val result: immutable.Seq[FeedSourceStatus] = Await.result(
         mockClient.get("")
-          .flatMap(res => Unmarshal[HttpResponse](res).to[List[FeedSourceStatus]]), 1 second)
+          .flatMap(res => Unmarshal[HttpResponse](res).to[List[FeedSourceStatus]]), 1.second)
 
       val expected = List(
         FeedSourceStatus(
@@ -44,7 +44,7 @@ class DrtPortDashboardSpec extends TestKit(ActorSystem("testActorSystem", Config
 
       val result: immutable.Seq[FeedSourceStatus] = Await.result(
         mockClient.get("")
-          .flatMap(res => Unmarshal[HttpResponse](res).to[List[FeedSourceStatus]]), 1 second)
+          .flatMap(res => Unmarshal[HttpResponse](res).to[List[FeedSourceStatus]]), 1.second)
 
       val expected = List(
         FeedSourceStatus(

--- a/src/test/scala/uk/gov/homeoffice/drt/DrtUrlSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/drt/DrtUrlSpec.scala
@@ -1,14 +1,14 @@
 package uk.gov.homeoffice.drt
 
 import org.specs2.mutable.Specification
-import uk.gov.homeoffice.drt.Dashboard.drtUriForPortCode
+import uk.gov.homeoffice.drt.Dashboard.drtInternalUriForPortCode
 
 class DrtUrlSpec extends Specification {
 
   "Given a port code and an endpoint I should get back an internal url that will work in kubernetes" >> {
     val portCode = "lhr"
 
-    val result = drtUriForPortCode(portCode)
+    val result = drtInternalUriForPortCode(portCode)
 
     val expected = "http://lhr:9000"
 

--- a/src/test/scala/uk/gov/homeoffice/drt/TimeFormatSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/drt/TimeFormatSpec.scala
@@ -2,7 +2,7 @@ package uk.gov.homeoffice.drt
 
 import org.joda.time.DateTime
 import org.specs2.mutable.Specification
-import uk.gov.homeoffice.drt.Dashboard.drtUriForPortCode
+import uk.gov.homeoffice.drt.Dashboard.drtInternalUriForPortCode
 
 class TimeFormatSpec extends Specification {
   import Dashboard.timeAgoInWords

--- a/src/test/scala/uk/gov/homeoffice/drt/rccu/ExportCsvServiceSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/drt/rccu/ExportCsvServiceSpec.scala
@@ -31,18 +31,7 @@ class ExportCsvServiceSpec extends Specification {
     val uri = exportCsvService.getUri("LHR", "2022-07-22", "2022-07-24", "T1")
     uri mustEqual expectedUri
   }
-
-  "Get response for given region port terminal" >> {
-    val response = Await.result(exportCsvService.getPortResponseForTerminal("2022-07-22", "2022-07-23", "Heathrow", "Heathrow", "T2"), 1.seconds).get
-
-    response.port must be("Heathrow")
-    response.regionName must be ("Heathrow")
-    response.terminal must be ("T2")
-    response.httpResponse.entity.dataBytes.fold(ByteString.empty)(_ ++ _).map(_.utf8String).runWith(Sink.head).map { csv =>
-      csv mustEqual csv
-    }
-  }
-
+  
   object MockHttpClient extends HttpClient {
     def send(httpRequest: HttpRequest)(implicit executionContext: ExecutionContextExecutor, mat: Materializer): Future[HttpResponse] = {
       if (httpRequest.getUri().path().contains("PIK")) {

--- a/src/test/scala/uk/gov/homeoffice/drt/routes/ExportRoutesSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/drt/routes/ExportRoutesSpec.scala
@@ -46,7 +46,7 @@ class ExportRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest
   }
 
   "Request South arrival export" should {
-    "collate all port and terminal arrivals in the North region" in {
+    "collate all port and terminal arrivals in the South region" in {
       Get("/export/South/2022-08-02/2022-08-03") ~> ExportRoutes(mockHttpClient) ~> check {
         val a = responseAs[String]
         a should ===(southRegionPortTerminalData)
@@ -55,7 +55,7 @@ class ExportRoutesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest
   }
 
   "Request Central arrival export" should {
-    "collate all port and terminal arrivals in the North region" in {
+    "collate all port and terminal arrivals in the Central region" in {
       Get("/export/Central/2022-08-02/2022-08-03") ~> ExportRoutes(mockHttpClient) ~> check {
         val a = responseAs[String]
         a should ===(centralRegionPortTerminalData)


### PR DESCRIPTION
Move consumption of response entity to same thread as the request is made to avoid a timeout