### PR TITLE
Role splits with semicolon to fix

### DIFF
--- a/src/main/scala/uk/gov/homeoffice/drt/authentication/User.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/authentication/User.scala
@@ -17,7 +17,7 @@ case class User(email: String, roles: Set[Role]) {
 
 object User {
   def fromRoles(email: String, roles: String): User = {
-    val rolesSeq: Array[String] = roles.split(",").map(_.split(":").last)
+    val rolesSeq: Array[String] = roles.split(",").map(_.split("role:").last)
     User(email, rolesSeq.flatMap(Roles.parse).toSet)
   }
 }


### PR DESCRIPTION
DRTII-1082 : Fixing the role splits in dashboard with oauth-proxy changes