### PR TITLE
DRTII-1516 replace reduce with fold to handle empty responses. Add test

### DIFF
--- a/src/main/scala/uk/gov/homeoffice/drt/rccu/ExportCsvService.scala
+++ b/src/main/scala/uk/gov/homeoffice/drt/rccu/ExportCsvService.scala
@@ -40,7 +40,7 @@ case class ExportCsvService(httpClient: HttpClient) {
         if (r.status == OK) {
           log.info(s"Got 200 response from $uri")
           r.entity.dataBytes
-            .runReduce(_ ++ _)
+            .runFold(ByteString.empty)(_ ++ _)
             .map(content => ByteString(content.utf8String))
             .recover { case e: Throwable =>
               log.error(s"Error while requesting export for $uri", e)


### PR DESCRIPTION
Use fold to protect against empty streams from empty responses from ports with no forecast flights